### PR TITLE
Update Yarn install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a starting point for all [Spree](https://spreecommerce.org)/Rails relate
  - PostgreSQL client - `brew install postgresql` or `apt-get install postgresql-client`
  - [RVM](https://rvm.io/) - `rvm use`
  - [NVM](https://github.com/creationix/nvm) - `nvm use`
- - Yarn - `npm install -g yarn`
+ - Yarn - `brew install yarn`
  - Bundler - `gem install bundler`
 
 ### Run setup script


### PR DESCRIPTION
It's not recommended installing `yarn` via `npm`.
Here's the note from Yarn website:

--- 
_Note: Installation of Yarn via npm is generally not recommended. When installing Yarn with Node-based package managers, the package is not signed, and the only integrity check performed is a basic SHA1 hash, which is a security risk when installing system-wide apps._

_For these reasons, it is highly recommended that you install Yarn through the installation method best suited to your operating system._

